### PR TITLE
Added error message for missing configuration

### DIFF
--- a/athenacli/main.py
+++ b/athenacli/main.py
@@ -77,12 +77,15 @@ class AthenaCli(object):
 
         try:
             self.connect(aws_config, database)
-        except:
+        except Exception as e:
             err_msg = '''
             There was an error while connecting to AWS Athena. It could be caused due to missing/incomplete configuration.
             Please verify the configuration in %s and run athenacli again.
+
+            For details about the error, you can check the log file at the location specified in the above config under log_file.
             ''' % ATHENACLIRC
             print(err_msg)
+            LOGGER.exception('error: %r', e)
             sys.exit(1)
 
         special.set_timing_enabled(_cfg['main'].as_bool('timing'))

--- a/athenacli/main.py
+++ b/athenacli/main.py
@@ -75,18 +75,15 @@ class AthenaCli(object):
             aws_access_key_id, aws_secret_access_key, region, s3_staging_dir, profile, _cfg
         )
 
-        if (not aws_config.aws_access_key_id
-                or not aws_config.aws_secret_access_key
-                or not aws_config.region
-                or not aws_config.s3_staging_dir):
+        try:
+            self.connect(aws_config, database)
+        except:
             err_msg = '''
-            Looks like some of the AWS configuration is missing/incomplete.
-            Please fix the configuration in %s and run athenacli again.
+            There was an error while connecting to AWS Athena. It could be caused due to missing/incomplete configuration.
+            Please verify the configuration in %s and run athenacli again.
             ''' % ATHENACLIRC
             print(err_msg)
             sys.exit(1)
-
-        self.connect(aws_config, database)
 
         special.set_timing_enabled(_cfg['main'].as_bool('timing'))
         self.multi_line = _cfg['main'].as_bool('multi_line')

--- a/athenacli/main.py
+++ b/athenacli/main.py
@@ -74,6 +74,18 @@ class AthenaCli(object):
         aws_config = AWSConfig(
             aws_access_key_id, aws_secret_access_key, region, s3_staging_dir, profile, _cfg
         )
+
+        if (not aws_config.aws_access_key_id
+                or not aws_config.aws_secret_access_key
+                or not aws_config.region
+                or not aws_config.s3_staging_dir):
+            err_msg = '''
+            Looks like some of the AWS configuration is missing/incomplete.
+            Please fix the configuration in %s and run athenacli again.
+            ''' % ATHENACLIRC
+            print(err_msg)
+            sys.exit(1)
+
         self.connect(aws_config, database)
 
         special.set_timing_enabled(_cfg['main'].as_bool('timing'))


### PR DESCRIPTION
Added temporary fix for issue #18 

Running `athenacli` without setting the mandatory parameters results in an error message prompting the user to go and add the configuration.



