### PR TITLE
Update README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# vscode
+.vscode/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ AthenaCLI is a command line interface (CLI) for the [Athena](https://aws.amazon.
 
 ![](./docs/_static/gif/athenacli.gif)
 
-# [Quick Start](https://athenacli.readthedocs.io/en/latest/index.html#quick-start)
+# Quick Start
 
 ## Install
 
@@ -36,6 +36,15 @@ region = '' # e.g us-west-2, us-east-1
 # NOTE: S3 should in the same region as specified above.
 # The format is 's3://<your s3 directory path>'
 s3_staging_dir = ''
+```
+
+or you can also use environment variables:
+
+``` bash
+$ export AWS_ACCESS_KEY_ID=YOUR_ACCESS_KEY_ID
+$ export AWS_SECRET_ACCESS_KEY=YOUR_SECRET_ACCESS_KEY
+$ export AWS_DEFAULT_REGION=us-west-2
+$ export AWS_ATHENA_S3_STAGING_DIR=s3://YOUR_S3_BUCKET/path/to/
 ```
 
 ## Create a table

--- a/README.md
+++ b/README.md
@@ -8,21 +8,97 @@ AthenaCLI is a command line interface (CLI) for the [Athena](https://aws.amazon.
 
 ![](./docs/_static/gif/athenacli.gif)
 
-# Quick Start
+# [Quick Start](https://athenacli.readthedocs.io/en/latest/index.html#quick-start)
 
-Please refer to the [Quick Start](https://athenacli.readthedocs.io/en/latest/index.html#quick-start) in the online documentation on how to get started using it quickly.
+## Install
+
+If you already know how to install python packages, then you can simply do:
+
+``` bash
+$ pip install athenacli
+```
+
+If you don't know how to install python packages, please check the [Install](./docs/install.rst) page for more options (e.g brew, docker)
+
+## Config
+
+A config file is automatically created at `~/.athenacli/athenaclirc` at first launch (run athenacli). See the file itself for a description of all available options.
+
+Below 4 variables are required. If you are a user of aws cli, you can refer to [awsconfig](./docs/awsconfig.rst) file to see how to reuse credentials configuration of aws cli.
+
+``` text
+# AWS credentials
+aws_access_key_id = ''
+aws_secret_access_key = ''
+region = '' # e.g us-west-2, us-east-1
+
+# Amazon S3 staging directory where query results are stored.
+# NOTE: S3 should in the same region as specified above.
+# The format is 's3://<your s3 directory path>'
+s3_staging_dir = ''
+```
+
+## Create a table
+
+``` bash
+$ athenacli -e examples/create_table.sql
+```
+
+You can find `examples/create_table.sql` [here](./examples/create_table.sql).
+
+## Run a query
+
+``` bash
+$ athenacli -e 'select elb_name, request_ip from elb_logs LIMIT 10'
+```
+
+## REPL
+
+``` bash
+$ athenacli [<database_name>]
+```
 
 # Features
 
-Please review the [Features](https://athenacli.readthedocs.io/en/latest/features.html) for information on what AthenaCLI provides.
+- Auto-completes as you type for SQL keywords as well as tables and columns in the database.
+- Syntax highlighting.
+- Smart-completion will suggest context-sensitive completion.
+    - `SELECT * FROM <tab>` will only show table names.
+    - `SELECT * FROM users WHERE <tab>` will only show column names.
+- Pretty prints tabular data and various table formats.
+- Some special commands. e.g. Favorite queries.
+- Alias support. Column completions will work even when table names are aliased.
+
+Please refer to the [Features](./docs/features.rst) page for the screenshots of above features.
 
 # Usages
+
+```bash
+$ athenacli --help
+Usage: main.py [OPTIONS] [DATABASE]
+
+A Athena terminal client with auto-completion and syntax highlighting.
+
+Examples:
+    - athenacli
+    - athenacli my_database
+
+Options:
+-e, --execute TEXT            Execute a command (or a file) and quit.
+-r, --region TEXT             AWS region.
+--aws-access-key-id TEXT      AWS access key id.
+--aws-secret-access-key TEXT  AWS secretaccess key.
+--s3-staging-dir TEXT         Amazon S3 staging directory where query
+                                results are stored.
+--athenaclirc PATH            Location of athenaclirc file.
+--help                        Show this message and exit.
+```
 
 Please go to the [Usages](https://athenacli.readthedocs.io/en/latest/usage.html) for detailed information on how to use AthenaCLI.
 
 # Contributions
 
-If you're interested in contributing to this project, first of all I would like to extend my heartfelt gratitude. I've written [a small doc](https://athenacli.readthedocs.io/en/latest/develop.html) to describe how to get this running in a development setup.
+If you're interested in contributing to this project, first of all I would like to extend my heartfelt gratitude. I've written a small [doc](https://athenacli.readthedocs.io/en/latest/develop.html) to describe how to get this running in a development setup.
 
 Please feel free to reach out to me if you need help. My email: zhuzhaolong0 AT gmail com
 

--- a/athenacli/main.py
+++ b/athenacli/main.py
@@ -78,13 +78,14 @@ class AthenaCli(object):
         try:
             self.connect(aws_config, database)
         except Exception as e:
+            self.echo(str(e), err=True, fg='red')
             err_msg = '''
-            There was an error while connecting to AWS Athena. It could be caused due to missing/incomplete configuration.
-            Please verify the configuration in %s and run athenacli again.
+There was an error while connecting to AWS Athena. It could be caused due to
+missing/incomplete configuration. Please verify the configuration in %s
+and run athenacli again.
 
-            For details about the error, you can check the log file at the location specified in the above config under log_file.
-            ''' % ATHENACLIRC
-            print(err_msg)
+For more details about the error, you can check the log file: %s''' % (ATHENACLIRC, _cfg['main']['log_file'])
+            self.echo(err_msg)
             LOGGER.exception('error: %r', e)
             sys.exit(1)
 


### PR DESCRIPTION
Describe how to install and how to configure the AWS credentials right in the Readme instead of linking out to the docs page. It is not very pleasant to jump to an external site while trying to get an idea of the project from Readme.

Thanks amjith's suggestion.