### PR TITLE
Add a "download" special command for fetching query results

### DIFF
--- a/athenacli/packages/special/iocommands.py
+++ b/athenacli/packages/special/iocommands.py
@@ -17,12 +17,17 @@ from . import export
 from .main import special_command, NO_QUERY, PARSED_QUERY
 from .utils import handle_cd_command
 
+OUTPUT_LOCATION = None
 TIMING_ENABLED = False
 use_expanded_output = False
 PAGER_ENABLED = True
 tee_file = None
 once_file = written_to_once_file = None
 
+@export
+def set_output_location(val):
+    global OUTPUT_LOCATION
+    OUTPUT_LOCATION = val
 
 @export
 def set_timing_enabled(val):
@@ -431,3 +436,12 @@ def watch_query(arg, **kwargs):
             return
         finally:
             set_pager_enabled(old_pager_enabled)
+
+@special_command('download', 'download', 'Download results from last query.', arg_type=NO_QUERY)
+def download():
+    if OUTPUT_LOCATION is None:
+        return [(None, None, None, "No OUTPUT_LOCATION from last query")]
+    else:
+        aws_s3_command = f"aws s3 cp {OUTPUT_LOCATION} /tmp/"
+        click.echo(f"Running: {aws_s3_command}")
+        return execute_system_command(aws_s3_command)

--- a/athenacli/sqlexecute.py
+++ b/athenacli/sqlexecute.py
@@ -85,6 +85,8 @@ class SQLExecute(object):
         '''Get the current result's data from the cursor.'''
         title = headers = None
 
+        special.set_output_location(cursor.output_location)
+
         # cursor.description is not None for queries that return result sets,
         # e.g. SELECT or SHOW.
         if cursor.description is not None:

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,13 @@
 (Unreleased; add upcoming change notes here)
 ==============================================
 
+1.2.0
+========
+
+Features
+----------
+* Add a download command to fetch query results to a local CSV. (Thanks: @pgr0ss)
+
 1.1.3
 ========
 


### PR DESCRIPTION
## Description

This change adds a `download` command which downloads the last query results from S3 to `/tmp`.

Here is what it looks like:

```
us-east-2:default> select 1 as one, 2 as two;
+-----+-----+
| one | two |
+-----+-----+
| 1   | 2   |
+-----+-----+
1 row in set
Time: 0.920s
us-east-2:default> download;
Running: aws s3 cp s3://bt-qa-athena-results-us-east-2/29b5ca78-890f-47b4-b3f2-967393e35a39.csv /tmp/
download: s3://bt-qa-athena-results-us-east-2/29b5ca78-890f-47b4-b3f2-967393e35a39.csv to ../../../../tmp/29b5ca78-890f-47b4-b3f2-967393e35a39.csv

Time: 0.951s
```
```
% cat /tmp/29b5ca78-890f-47b4-b3f2-967393e35a39.csv
"one","two"
"1","2"
```

I am still new to this codebase, so please let me know if you'd like it implemented a different way. Roughly:
- Store the `output_location` from the cursor on every query
- Add a `download` special command which fetches the CSV
- Use `aws` tool for simplicity and inheriting AWS credentials

Addresses part of #37.

## Checklist
- [X] I've added this contribution to the `changelog.md`.
- [X] I've added my name to the `AUTHORS` file (or it's already there).
