### PR TITLE
Show query execution statistics

### DIFF
--- a/athenacli/packages/format_utils.py
+++ b/athenacli/packages/format_utils.py
@@ -12,9 +12,13 @@ def rows_status(rows_length):
 
 def statistics(cursor):
     if cursor:
-        return '\nExecution time: %d ms, Data scanned: %s' % (
+        # Most regions are $5 per TB: https://aws.amazon.com/athena/pricing/
+        approx_cost = cursor.data_scanned_in_bytes / (1024 ** 4) * 5
+
+        return '\nExecution time: %d ms, Data scanned: %s, Approximate cost: $%.2f' % (
                 cursor.execution_time_in_millis,
-                humanize_size(cursor.data_scanned_in_bytes))
+                humanize_size(cursor.data_scanned_in_bytes),
+                approx_cost)
     else:
         return ''
 

--- a/athenacli/packages/format_utils.py
+++ b/athenacli/packages/format_utils.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+
+
+def format_status(rows_length):
+    if rows_length:
+        return '%d row%s in set' % (rows_length, '' if rows_length == 1 else 's')
+    else:
+        return 'Query OK'

--- a/athenacli/packages/format_utils.py
+++ b/athenacli/packages/format_utils.py
@@ -1,8 +1,30 @@
 # -*- coding: utf-8 -*-
 
 
-def format_status(rows_length):
+def format_status(rows_length=None, cursor=None):
+    return rows_status(rows_length) + statistics(cursor)
+
+def rows_status(rows_length):
     if rows_length:
         return '%d row%s in set' % (rows_length, '' if rows_length == 1 else 's')
     else:
         return 'Query OK'
+
+def statistics(cursor):
+    if cursor:
+        return '\nExecution time: %d ms, Data scanned: %s' % (
+                cursor.execution_time_in_millis,
+                humanize_size(cursor.data_scanned_in_bytes))
+    else:
+        return ''
+
+def humanize_size(num_bytes):
+    suffixes = ['B', 'KB', 'MB', 'GB', 'TB']
+
+    suffix_index = 0
+    while num_bytes >= 1024 and suffix_index < len(suffixes) - 1:
+        num_bytes /= 1024.0
+        suffix_index += 1
+
+    num = ('%.2f' % num_bytes).rstrip('0').rstrip('.')
+    return '%s %s' % (num, suffixes[suffix_index])

--- a/athenacli/sqlexecute.py
+++ b/athenacli/sqlexecute.py
@@ -93,11 +93,11 @@ class SQLExecute(object):
         if cursor.description is not None:
             headers = [x[0] for x in cursor.description]
             rows = cursor.fetchall()
-            status = format_status(len(rows))
+            status = format_status(rows_length=len(rows), cursor=cursor)
         else:
             logger.debug('No rows in result.')
             rows = None
-            status = format_status(None)
+            status = format_status(rows_length=None, cursor=cursor)
         return (title, rows, headers, status)
 
     def tables(self):

--- a/athenacli/sqlexecute.py
+++ b/athenacli/sqlexecute.py
@@ -5,6 +5,7 @@ import sqlparse
 import pyathena
 
 from athenacli.packages import special
+from athenacli.packages.format_utils import format_status
 
 logger = logging.getLogger(__name__)
 
@@ -92,11 +93,11 @@ class SQLExecute(object):
         if cursor.description is not None:
             headers = [x[0] for x in cursor.description]
             rows = cursor.fetchall()
-            status = '%d row%s in set' % (len(rows), '' if len(rows) == 1 else 's')
+            status = format_status(len(rows))
         else:
             logger.debug('No rows in result.')
             rows = None
-            status = 'Query OK'
+            status = format_status(None)
         return (title, rows, headers, status)
 
     def tables(self):

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,13 @@
 (Unreleased; add upcoming change notes here)
 ==============================================
 
+1.3.0
+========
+
+Features
+----------
+* Show query execution statistics, such as the amount of data scanned and the approximate cost. (Thanks: @pgr0ss)
+
 1.2.0
 ========
 

--- a/test/test_format_utils.py
+++ b/test/test_format_utils.py
@@ -14,9 +14,9 @@ def test_format_status_no_results():
 
 def test_format_status_with_stats():
     FakeCursor = namedtuple("FakeCursor", ["execution_time_in_millis", "data_scanned_in_bytes"])
-    fake_cursor = FakeCursor(10, 123456789)
 
-    assert format_status(rows_length=1, cursor=fake_cursor) == "1 row in set\nExecution time: 10 ms, Data scanned: 117.74 MB"
+    assert format_status(rows_length=1, cursor=FakeCursor(10, 12345678900)) == "1 row in set\nExecution time: 10 ms, Data scanned: 11.5 GB, Approximate cost: $0.06"
+    assert format_status(rows_length=2, cursor=FakeCursor(1000, 1234)) == "2 rows in set\nExecution time: 1000 ms, Data scanned: 1.21 KB, Approximate cost: $0.00"
 
 def test_humanize_size():
     assert humanize_size(20) == "20 B"

--- a/test/test_format_utils.py
+++ b/test/test_format_utils.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+
+
+from athenacli.packages.format_utils import format_status
+
+
+def test_format_status():
+    assert format_status(1) == "1 row in set"
+    assert format_status(2) == "2 rows in set"
+    assert format_status(None) == "Query OK"

--- a/test/test_format_utils.py
+++ b/test/test_format_utils.py
@@ -1,10 +1,26 @@
 # -*- coding: utf-8 -*-
 
 
-from athenacli.packages.format_utils import format_status
+from collections import namedtuple
+from athenacli.packages.format_utils import format_status, humanize_size
 
 
-def test_format_status():
-    assert format_status(1) == "1 row in set"
-    assert format_status(2) == "2 rows in set"
-    assert format_status(None) == "Query OK"
+def test_format_status_plural():
+    assert format_status(rows_length=1) == "1 row in set"
+    assert format_status(rows_length=2) == "2 rows in set"
+
+def test_format_status_no_results():
+    assert format_status(rows_length=None) == "Query OK"
+
+def test_format_status_with_stats():
+    FakeCursor = namedtuple("FakeCursor", ["execution_time_in_millis", "data_scanned_in_bytes"])
+    fake_cursor = FakeCursor(10, 123456789)
+
+    assert format_status(rows_length=1, cursor=fake_cursor) == "1 row in set\nExecution time: 10 ms, Data scanned: 117.74 MB"
+
+def test_humanize_size():
+    assert humanize_size(20) == "20 B"
+    assert humanize_size(2000) == "1.95 KB"
+    assert humanize_size(200000) == "195.31 KB"
+    assert humanize_size(20000000) == "19.07 MB"
+    assert humanize_size(200000000000) == "186.26 GB"


### PR DESCRIPTION
## Description

My goal with this is to replicate some query statistics our old athena cli was printing (closes #39).

It looks like this:

```
12 rows in set
Execution time: 10934 ms, Data scanned: 2.54 GB, Approximate cost: $0.01
Time: 11.960s
```

This is a bigger change, so please let me know if there's a better way to implement it. 

I originally looked to do something in the main loop, similar to where the code already prints the time: https://github.com/dbcli/athenacli/blob/c0e6869d7c023c3c2a2bda7f40f09286f5d0c0c0/athenacli/main.py#L321

However, that would mean adding another value to `(title, rows, headers, status)` and it seemed like a pretty invasive change (maybe a good candidate for a dataclass instead of a tuple in the future).

Instead, I add this new info onto the end of the status so it gets printed along with that. I extracted that code to format_utils.py, added the functionality, and wrapped it in tests.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [X] I've added this contribution to the `changelog.md`.
- [X] I've added my name to the `AUTHORS` file (or it's already there).
