### PR TITLE
Add `arn_role` for aws assume role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ target/
 # vscode
 .vscode/
 .venv/
+.python-version

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -16,6 +16,7 @@ Contributors:
   * Hourann
   * Paul Gross
   * Aaron Brager
+  * Patrick Park
 
 Creator:
 --------

--- a/athenacli/completion_refresher.py
+++ b/athenacli/completion_refresher.py
@@ -53,11 +53,12 @@ class CompletionRefresher(object):
         # Create a new pgexecute method to popoulate the completions.
         e = sqlexecute
         executor = SQLExecute(
-            e.aws_access_key_id,
-            e.aws_secret_access_key,
-            e.region_name,
-            e.s3_staging_dir,
-            e.database
+            aws_access_key_id = e.aws_access_key_id,
+            aws_secret_access_key = e.aws_secret_access_key,
+            region_name = e.region_name,
+            s3_staging_dir = e.s3_staging_dir,
+            assume_role_arn = e.assume_role_arn,
+            database = e.database
         )
 
         # If callbacks is a single function then push it into a list.

--- a/athenacli/completion_refresher.py
+++ b/athenacli/completion_refresher.py
@@ -57,7 +57,7 @@ class CompletionRefresher(object):
             aws_secret_access_key = e.aws_secret_access_key,
             region_name = e.region_name,
             s3_staging_dir = e.s3_staging_dir,
-            assume_role_arn = e.assume_role_arn,
+            role_arn = e.role_arn,
             database = e.database
         )
 

--- a/athenacli/config.py
+++ b/athenacli/config.py
@@ -26,6 +26,8 @@ class AWSConfig(object):
         self.aws_secret_access_key = self.get_val(aws_secret_access_key, _cfg['aws_secret_access_key'])
         self.region = self.get_val(region, _cfg['region'], self.get_region())
         self.s3_staging_dir = self.get_val(s3_staging_dir, _cfg['s3_staging_dir'])
+        # enable connection to assume role
+        self.assume_role_arn = self.get_val(_cfg.get('assume_role_arn'))
 
     def get_val(self, *vals):
         """Return the first True value in `vals` list, otherwise return None."""

--- a/athenacli/config.py
+++ b/athenacli/config.py
@@ -27,7 +27,7 @@ class AWSConfig(object):
         self.region = self.get_val(region, _cfg['region'], self.get_region())
         self.s3_staging_dir = self.get_val(s3_staging_dir, _cfg['s3_staging_dir'])
         # enable connection to assume role
-        self.assume_role_arn = self.get_val(_cfg.get('assume_role_arn'))
+        self.role_arn = self.get_val(_cfg.get('role_arn'))
 
     def get_val(self, *vals):
         """Return the first True value in `vals` list, otherwise return None."""

--- a/athenacli/main.py
+++ b/athenacli/main.py
@@ -195,7 +195,7 @@ For more details about the error, you can check the log file: %s''' % (ATHENACLI
             aws_secret_access_key = aws_config.aws_secret_access_key,
             region_name = aws_config.region,
             s3_staging_dir = aws_config.s3_staging_dir,
-            assume_role_arn = aws_config.assume_role_arn,
+            role_arn = aws_config.role_arn,
             database = database
         )
 

--- a/athenacli/main.py
+++ b/athenacli/main.py
@@ -191,11 +191,12 @@ For more details about the error, you can check the log file: %s''' % (ATHENACLI
 
     def connect(self, aws_config, database):
         self.sqlexecute = SQLExecute(
-            aws_config.aws_access_key_id,
-            aws_config.aws_secret_access_key,
-            aws_config.region,
-            aws_config.s3_staging_dir,
-            database
+            aws_access_key_id = aws_config.aws_access_key_id,
+            aws_secret_access_key = aws_config.aws_secret_access_key,
+            region_name = aws_config.region,
+            s3_staging_dir = aws_config.s3_staging_dir,
+            assume_role_arn = aws_config.assume_role_arn,
+            database = database
         )
 
     def handle_editor_command(self, text):

--- a/athenacli/sqlexecute.py
+++ b/athenacli/sqlexecute.py
@@ -25,14 +25,14 @@ class SQLExecute(object):
         aws_secret_access_key,
         region_name,
         s3_staging_dir,
-        assume_role_arn,
+        role_arn,
         database
     ):
         self.aws_access_key_id = aws_access_key_id
         self.aws_secret_access_key = aws_secret_access_key
         self.region_name = region_name
         self.s3_staging_dir = s3_staging_dir
-        self.assume_role_arn = assume_role_arn
+        self.role_arn = role_arn
         self.database = database
 
         self.connect()
@@ -44,7 +44,7 @@ class SQLExecute(object):
             region_name=self.region_name,
             s3_staging_dir=self.s3_staging_dir,
             schema_name=database or self.database,
-            role_arn=self.assume_role_arn,
+            role_arn=self.role_arn,
             poll_interval=0.2 # 200ms
         )
         self.database = database or self.database

--- a/athenacli/sqlexecute.py
+++ b/athenacli/sqlexecute.py
@@ -25,12 +25,14 @@ class SQLExecute(object):
         aws_secret_access_key,
         region_name,
         s3_staging_dir,
+        assume_role_arn,
         database
     ):
         self.aws_access_key_id = aws_access_key_id
         self.aws_secret_access_key = aws_secret_access_key
         self.region_name = region_name
         self.s3_staging_dir = s3_staging_dir
+        self.assume_role_arn = assume_role_arn
         self.database = database
 
         self.connect()
@@ -42,6 +44,7 @@ class SQLExecute(object):
             region_name=self.region_name,
             s3_staging_dir=self.s3_staging_dir,
             schema_name=database or self.database,
+            role_arn=self.assume_role_arn,
             poll_interval=0.2 # 200ms
         )
         self.database = database or self.database

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,6 @@
 (Unreleased; add upcoming change notes here)
+* Add support for `arn_role` in athenaclirc file to allow connection to assume 
+aws role
 ==============================================
 
 Internal:


### PR DESCRIPTION
## Description
PyAthena can "assume role" if role_arn is passed to the connection. This change loads the role_arn value from athenaclirc if it exists.

## Checklist
- [X] I've added this contribution to the `changelog.md`.
- [X] I've added my name to the `AUTHORS` file (or it's already there).
