### PR TITLE
Do not require a specific profile section in the athenacli config and allow not to generate the default config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ target/
 .vscode/
 .venv/
 .python-version
+
+# Jetbrains Editors
+.idea/

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -17,6 +17,7 @@ Contributors:
   * Paul Gross
   * Aaron Brager
   * Patrick Park
+  * Jan Katins
 
 Creator:
 --------

--- a/athenacli/config.py
+++ b/athenacli/config.py
@@ -5,6 +5,7 @@ import sys
 import errno
 import boto3
 from configobj import ConfigObj, ConfigObjError
+from collections import defaultdict
 
 
 try:
@@ -20,7 +21,13 @@ class AWSConfig(object):
     def __init__(self, aws_access_key_id, aws_secret_access_key,
                  region, s3_staging_dir, profile, config):
         key = 'aws_profile %s' % profile
-        _cfg = config[key]
+        try:
+            _cfg = config[key]
+        except:
+            # this assumes that the profile is only known in the regular AWS config -> the boto lib will get it
+            # from there. This is especially important if we have some kind of additional temporary session keys for
+            # which the login fails if we set aws_access_key_id/aws_secret_access_key here
+            _cfg = defaultdict(lambda: None)
 
         self.aws_access_key_id = self.get_val(aws_access_key_id, _cfg['aws_access_key_id'])
         self.aws_secret_access_key = self.get_val(aws_secret_access_key, _cfg['aws_secret_access_key'])

--- a/athenacli/main.py
+++ b/athenacli/main.py
@@ -62,7 +62,9 @@ class AthenaCli(object):
     def __init__(self, region, aws_access_key_id, aws_secret_access_key,
                  s3_staging_dir, athenaclirc, profile, database):
 
-        config_files = (DEFAULT_CONFIG_FILE, athenaclirc)
+        config_files = [DEFAULT_CONFIG_FILE]
+        if os.path.exists(athenaclirc):
+            config_files.append(athenaclirc)
         _cfg = self.config = read_config_files(config_files)
 
         self.init_logging(_cfg['main']['log_file'], _cfg['main']['log_level'])
@@ -523,7 +525,7 @@ For more details about the error, you can check the log file: %s''' % (ATHENACLI
                 editing_mode = EditingMode.VI
             else:
                 editing_mode = EditingMode.EMACS
-            
+
             self.prompt_app = PromptSession(
                 lexer=PygmentsLexer(Lexer),
                 reserve_space_for_menu=self.get_reserved_space(),
@@ -621,7 +623,7 @@ def cli(execute, region, aws_access_key_id, aws_secret_access_key,
       - athenacli
       - athenacli my_database
     '''
-    if (athenaclirc == ATHENACLIRC) and (not os.path.exists(os.path.expanduser(ATHENACLIRC))):
+    if athenaclirc and (athenaclirc == ATHENACLIRC) and (not os.path.exists(os.path.expanduser(ATHENACLIRC))):
         err_msg = '''
         Welcome to athenacli!
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 Features:
 ----------
 * Add support for `role_arn` in athenaclirc file to allow connection to assume aws role. (Thanks: @pdpark)
+* Allow using an empty `--athenaclirc=` to not generate the default config file on first start (Thanks: @jankatins)
 * Allow starting with `--profile=<aws_profile_name>` without having a corresponding entry in the `athenaclirc` config
   file (Thanks: @jankatins) 
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 Features:
 ----------
 * Add support for `role_arn` in athenaclirc file to allow connection to assume aws role. (Thanks: @pdpark)
+* Allow starting with `--profile=<aws_profile_name>` without having a corresponding entry in the `athenaclirc` config
+  file (Thanks: @jankatins) 
 
 1.3.3
 ========


### PR DESCRIPTION
## Description

We use some kind of mechanism to generate temporary AWS credentials. These show up in $HOME/.aws/credentials
with an additional aws_session_token in a separate profile. The change here makes it possible to use these credentials
without adding a specific section for this temporary profile to the athena config file.

Before this change this would fail as the profile would not be found and error out.

In addition, add a way to not generate the config (and fail) on first run. This is needed in our case as we run in a docker container and would need to include a fake athenaclirc even as we would pass all needed config on the commandline


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
