### PR TITLE
Allow sql on stdin

### DIFF
--- a/athenacli/main.py
+++ b/athenacli/main.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 import sys
+import select
 import click
 import threading
 import logging
@@ -651,7 +652,12 @@ def cli(execute, region, aws_access_key_id, aws_secret_access_key,
 
     #  --execute argument
     if execute:
-        if os.path.exists(execute):
+        if execute == '-':
+            if select.select([sys.stdin, ], [], [], 0.0)[0]:
+                query = sys.stdin.read()
+            else:
+                raise RuntimeError("No query to execute on stdin")
+        elif os.path.exists(execute):
             with open(execute) as f:
                 query = f.read()
         else:

--- a/athenacli/main.py
+++ b/athenacli/main.py
@@ -624,7 +624,7 @@ def cli(execute, region, aws_access_key_id, aws_secret_access_key,
       - athenacli
       - athenacli my_database
     '''
-    if athenaclirc and (athenaclirc == ATHENACLIRC) and (not os.path.exists(os.path.expanduser(ATHENACLIRC))):
+    if (athenaclirc == ATHENACLIRC) and (not os.path.exists(os.path.expanduser(ATHENACLIRC))):
         err_msg = '''
         Welcome to athenacli!
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,8 @@ Features:
 * Allow using an empty `--athenaclirc=` to not generate the default config file on first start (Thanks: @jankatins)
 * Allow starting with `--profile=<aws_profile_name>` without having a corresponding entry in the `athenaclirc` config
   file (Thanks: @jankatins) 
+* Add support for supplying the SQL query on stdin by using `-` (minus) as query string: `--execute=-`. 
+  (Thanks: @jankatins)
 
 1.3.3
 ========


### PR DESCRIPTION
## Description
Add support for supplying the SQL query on stdin by using `-` (minus) as query string: `--execute=-`. 

Closes: #53

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
