### PR TITLE
Improve performance of CSV formatter when handling NULLs

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -18,6 +18,7 @@ Contributors:
   * Aaron Brager
   * Patrick Park
   * Jan Katins
+  * Jason Yan
 
 Creator:
 --------

--- a/athenacli/main.py
+++ b/athenacli/main.py
@@ -432,8 +432,9 @@ For more details about the error, you can check the log file: %s''' % (athenacli
             'disable_numparse': True,
             'preserve_whitespace': True,
             'preprocessors': (preprocessors.align_decimals, ),
-            'style': self.output_style
         }
+        if self.formatter.format_name != 'csv':
+            output_kwargs['style'] = self.output_style
 
         if title:  # Only print the title if it's not None.
             output = itertools.chain(output, [title])

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,8 @@
 (Unreleased; add upcoming change notes here)
 ==============================================
 
+* Improve performance of CSV formatter when handling NULLs
+
 1.4.1
 =========
 


### PR DESCRIPTION
When using `table_format = csv`, the default value for missing values is
the empty string which we don't override, but `cli_helpers` still tries
to style this which is fairly costly.