### PR TITLE
Add "read" command to read and execute a SQL file

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -18,6 +18,7 @@ Contributors:
   * Aaron Brager
   * Patrick Park
   * Jan Katins
+  * Scott Morgan
 
 Creator:
 --------

--- a/athenacli/packages/special/iocommands.py
+++ b/athenacli/packages/special/iocommands.py
@@ -219,7 +219,7 @@ def subst_favorite_query_args(query, args):
 
     return [query, None]
 
-@special_command('load', 'load [filename]', 'Load and execute query from a file.')
+@special_command('read', 'read [filename]', 'Read and execute query from a file.')
 def execute_file_query(cur, arg, **_):
     filename = arg
     if filename:
@@ -227,6 +227,9 @@ def execute_file_query(cur, arg, **_):
             with open(filename, encoding='utf-8') as f:
                 query = f.read()
                 for sql in sqlparse.split(query):
+                    if not sql:
+                        continue
+
                     _logger.debug("query is [%s]", sql)
                     sql = sql.rstrip(';')
                     destructive_prompt = confirm_destructive_query(sql)

--- a/athenacli/packages/special/iocommands.py
+++ b/athenacli/packages/special/iocommands.py
@@ -219,34 +219,34 @@ def subst_favorite_query_args(query, args):
 
     return [query, None]
 
- @special_command('load', 'load [filename]', 'Load and execute query from a file.')
- def execute_file_query(cur, arg, **_):
-     filename = arg
-     if filename:
-         try:
-             with open(filename, encoding='utf-8') as f:
-                 query = f.read()
-                 for sql in sqlparse.split(query):
-                     _logger.debug("query is [%s]", sql)
-                     sql = sql.rstrip(';')
-                     destructive_prompt = confirm_destructive_query(sql)
-                     if destructive_prompt is False:
-                         click.secho("Wise choice!")
-                         return
-                     elif destructive_prompt is True:
-                         click.secho("Your call!")
+@special_command('load', 'load [filename]', 'Load and execute query from a file.')
+def execute_file_query(cur, arg, **_):
+    filename = arg
+    if filename:
+        try:
+            with open(filename, encoding='utf-8') as f:
+                query = f.read()
+                for sql in sqlparse.split(query):
+                    _logger.debug("query is [%s]", sql)
+                    sql = sql.rstrip(';')
+                    destructive_prompt = confirm_destructive_query(sql)
+                    if destructive_prompt is False:
+                        click.secho("Wise choice!")
+                        return
+                    elif destructive_prompt is True:
+                        click.secho("Your call!")
 
-                     title = '%s' % (sql)
-                     cur.execute(sql)
-                     if cur.description:
-                         headers = [x[0] for x in cur.description]
-                         yield (title, cur.fetchall(), headers, None)
-                     else:
-                         yield (title, None, None, None)
+                    title = '%s' % (sql)
+                    cur.execute(sql)
+                    if cur.description:
+                        headers = [x[0] for x in cur.description]
+                        yield (title, cur.fetchall(), headers, None)
+                    else:
+                        yield (title, None, None, None)
 
-         except IOError:
-             message = 'Error reading file: %s.' % filename
-             yield (None, None, None, message)
+        except IOError:
+            message = 'Error reading file: %s.' % filename
+            yield (None, None, None, message)
 
 @special_command('\\fs', '\\fs name query', 'Save a favorite query.')
 def save_favorite_query(arg, **_):

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,10 @@
 (Unreleased; add upcoming change notes here)
 ==============================================
 
+Features:
+----------
+* Add a load command to load and execute a SQL file while in the REPL. (Thanks: @sco11morgan)
+
 1.4.1
 =========
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Add command to allow executing a query file while inside the REPL.

Heavily borrowed from `execute_favorite_query` and `watch_query` commands.

Resolves https://github.com/dbcli/athenacli/issues/60


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
