### PR TITLE
update execution_time_in_millis as lib PyAthena has updated

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -21,6 +21,7 @@ Contributors:
   * Rui Chen
   * Scott Morgan
   * Deepu Mohan Puthrote
+  * Toska Chin
 
 Creator:
 --------

--- a/athenacli/packages/format_utils.py
+++ b/athenacli/packages/format_utils.py
@@ -16,7 +16,7 @@ def statistics(cursor):
         approx_cost = cursor.data_scanned_in_bytes / (1024 ** 4) * 5
 
         return '\nExecution time: %d ms, Data scanned: %s, Approximate cost: $%.2f' % (
-                cursor.execution_time_in_millis,
+                cursor.engine_execution_time_in_millis,
                 humanize_size(cursor.data_scanned_in_bytes),
                 approx_cost)
     else:

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 (Unreleased; add upcoming change notes here)
 ==============================================
+1.6.1
+=========
+
+Bugfix:
+----------
+* update cursor.execution_time_in_millis to cursor.engine_execution_time_in_millis as libary PyAthena removed execution_time_in_millis 
 
 1.6.0
 =========

--- a/test/test_format_utils.py
+++ b/test/test_format_utils.py
@@ -13,7 +13,7 @@ def test_format_status_no_results():
     assert format_status(rows_length=None) == "Query OK"
 
 def test_format_status_with_stats():
-    FakeCursor = namedtuple("FakeCursor", ["execution_time_in_millis", "data_scanned_in_bytes"])
+    FakeCursor = namedtuple("FakeCursor", ["engine_execution_time_in_millis", "data_scanned_in_bytes"])
 
     assert format_status(rows_length=1, cursor=FakeCursor(10, 12345678900)) == "1 row in set\nExecution time: 10 ms, Data scanned: 11.5 GB, Approximate cost: $0.06"
     assert format_status(rows_length=2, cursor=FakeCursor(1000, 1234)) == "2 rows in set\nExecution time: 1000 ms, Data scanned: 1.21 KB, Approximate cost: $0.00"


### PR DESCRIPTION
## Description
<!--- The lib PyAthena has replaced execution_time_in_millis  -->

https://github.com/laughingman7743/PyAthena/commit/dad812d4e2bf69683bfb73e56ca3c01f72b4f396

Test Env, Centos 6.10, python 2.6 and python 3.6

`us-east-1:default> show TABLES;
'Cursor' object has no attribute 'execution_time_in_millis'`

After the change
`us-east-1:default> show TABLES;
Query OK
Execution time: 240 ms, Data scanned: 0 B, Approximate cost: $0.00`

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
