### PR TITLE
Add --tableformat option to specify output for -e

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -22,6 +22,7 @@ Contributors:
   * Scott Morgan
   * Deepu Mohan Puthrote
   * Toska Chin
+  * Pete Sheridan
 
 Creator:
 --------

--- a/athenacli/main.py
+++ b/athenacli/main.py
@@ -616,9 +616,10 @@ def is_mutating(status):
 @click.option('--work_group', type=str, help="Amazon Athena workgroup in which query is run, default is primary")
 @click.option('--athenaclirc', default=ATHENACLIRC, type=click.Path(dir_okay=False), help="Location of athenaclirc file.")
 @click.option('--profile', type=str, default='default', help='AWS profile')
+@click.option('--tableformat', type=str, default='csv', help='Table format used with -e option.')
 @click.argument('database', default='default', nargs=1)
 def cli(execute, region, aws_access_key_id, aws_secret_access_key,
-        s3_staging_dir, work_group, athenaclirc, profile, database):
+        s3_staging_dir, work_group, athenaclirc, profile, tableformat, database):
     '''A Athena terminal client with auto-completion and syntax highlighting.
 
     \b
@@ -666,7 +667,7 @@ def cli(execute, region, aws_access_key_id, aws_secret_access_key,
         else:
             query = execute
         try:
-            athenacli.formatter.format_name = 'csv'
+            athenacli.formatter.format_name = tableformat
             athenacli.run_query(query)
             exit(0)
         except Exception as e:

--- a/athenacli/main.py
+++ b/athenacli/main.py
@@ -616,10 +616,10 @@ def is_mutating(status):
 @click.option('--work_group', type=str, help="Amazon Athena workgroup in which query is run, default is primary")
 @click.option('--athenaclirc', default=ATHENACLIRC, type=click.Path(dir_okay=False), help="Location of athenaclirc file.")
 @click.option('--profile', type=str, default='default', help='AWS profile')
-@click.option('--tableformat', type=str, default='csv', help='Table format used with -e option.')
+@click.option('--table-format', type=str, default='csv', help='Table format used with -e option.')
 @click.argument('database', default='default', nargs=1)
 def cli(execute, region, aws_access_key_id, aws_secret_access_key,
-        s3_staging_dir, work_group, athenaclirc, profile, tableformat, database):
+        s3_staging_dir, work_group, athenaclirc, profile, table_format, database):
     '''A Athena terminal client with auto-completion and syntax highlighting.
 
     \b
@@ -667,7 +667,7 @@ def cli(execute, region, aws_access_key_id, aws_secret_access_key,
         else:
             query = execute
         try:
-            athenacli.formatter.format_name = tableformat
+            athenacli.formatter.format_name = table_format
             athenacli.run_query(query)
             exit(0)
         except Exception as e:

--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,7 @@
 
 Features:
 ----------
-* Add `--tableformat` to change format used in `-e` mode.
+* Add `--table-format` to change format used in `-e` mode.
 
 1.6.1
 =========

--- a/changelog.md
+++ b/changelog.md
@@ -1,12 +1,16 @@
 (Unreleased; add upcoming change notes here)
 ==============================================
 
+Features:
+----------
+* Add `--tableformat` to change format used in `-e` mode.
+
 1.6.1
 =========
 
 Bugfix:
 ----------
-* update cursor.execution_time_in_millis to cursor.engine_execution_time_in_millis as libary PyAthena removed execution_time_in_millis 
+* update cursor.execution_time_in_millis to cursor.engine_execution_time_in_millis as libary PyAthena removed execution_time_in_millis
 
 1.6.0
 =========


### PR DESCRIPTION
## Description
Simply adds a click option, `--tableformat`, to allow specification of output formatter along with `-e`. This was previously hardcoded to 'csv'.

Example:

    athenacli -e 'select * from mydb.mytable limit 10' --tableformat ascii

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
