### PR TITLE
Pin Pygments

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -23,6 +23,7 @@ Contributors:
   * Deepu Mohan Puthrote
   * Toska Chin
   * Pete Sheridan
+  * Anthony Ross
 
 Creator:
 --------

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,8 @@
 (Unreleased; add upcoming change notes here)
 ==============================================
 
+* Pinned pygments due to regression in 2.11.2
+
 1.6.2
 =========
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open("README.md", "r") as fh:
 
 install_requirements = [
     'click>=7.0',
-    'Pygments>=1.6',
+    'Pygments>=1.6,<=2.11.1',
     'prompt_toolkit>=2.0.6,<3.0.0',
     'sqlparse>=0.3.0,<0.4.0',
     'configobj>=5.0.5',


### PR DESCRIPTION
Pygments made a backwards incompatible change resulting in error
messages like:

```
2022-01-10 20:00:55,648 (3535/MainThread) athenacli.main ERROR - traceback: 'Traceback (most recent call last):
  File "/home/admin/.local/lib/python3.7/site-packages/pygments/formatters/terminal256.py", line 261, in format_unencoded
    on, off = self.style_string[str(ttype)]
KeyError: \'Token.Output.TableSeparator\'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/admin/.local/lib/python3.7/site-packages/athenacli/main.py", line 312, in one_iteration

title, rows, headers, special.is_expanded_output(), None
  File "/home/admin/.local/lib/python3.7/site-packages/athenacli/main.py", line 453, in format_output
    **output_kwargs)
```

This is a result of https://github.com/pygments/pygments/commit/8fdd6b9879a6c34b908fa03a6ff15f764192a54e

See related error for pgcli - https://github.com/dbcli/pgcli/issues/1303

See main pygments issue - https://github.com/pygments/pygments/issues/2027

## Description
<!--- Describe your changes in detail. -->

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [ ] I've added my name to the `AUTHORS` file (or it's already there).
