### PR TITLE
bump sqlparse dependency max version

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -25,6 +25,7 @@ Contributors:
   * Pete Sheridan
   * Anthony Ross
   * Li Ben Yuan
+  * Alex Gaynor
 
 Creator:
 --------

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 TBD
 =====
 
+* Update sqlparse dependency max version
 
 1.6.6 (2022/05/09)
 ==================

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ install_requirements = [
     'click>=7.0',
     'Pygments>=1.6,<=2.11.1',
     "prompt_toolkit>=3.0.3,<4.0.0",
-    'sqlparse>=0.3.0,<0.4.0',
+    'sqlparse>=0.3.0,<0.5.0',
     'configobj>=5.0.5',
     'cli_helpers[styles]>=1.1.0',
     'botocore>=1.5.52',


### PR DESCRIPTION
Local testing passes with this

## Description
Allows installing the latest version of sqlparse.

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).

Not sure if this is worthy of a changelog entry, if you'd like one I can add one.